### PR TITLE
feat: support pinned upstream QEMU ACPI generation

### DIFF
--- a/Dockerfile.qemu-acpi-dump
+++ b/Dockerfile.qemu-acpi-dump
@@ -7,8 +7,10 @@ FROM ${DISTRIBUTION}
 # QEMU_SOURCE selects how the source tarball is fetched:
 #   "ppa"  -> pull-ppa-source from ppa:kobuk-team/tdx-release (Intel TDX QEMU build for 24.04/25.04)
 #   "main" -> pull-lp-source from the distribution's main archive
+#   "upstream" -> download the signed-release tarball from download.qemu.org
 ARG QEMU_SOURCE=ppa
 ARG QEMU_VERSION=
+ARG QEMU_SHA256=
 ARG ACPI_TABLES_NAME
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,6 +19,8 @@ RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
         build-essential \
         git \
+        curl \
+        xz-utils \
         ubuntu-dev-tools \
         libglib2.0-dev \
         meson \
@@ -30,6 +34,10 @@ RUN if [ "$QEMU_SOURCE" = "ppa" ]; then \
         pull-ppa-source --ppa ppa:kobuk-team/tdx-release qemu ${QEMU_VERSION}; \
     elif [ "$QEMU_SOURCE" = "main" ]; then \
         pull-lp-source qemu ${QEMU_VERSION}; \
+    elif [ "$QEMU_SOURCE" = "upstream" ]; then \
+        curl -fsSLO "https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz"; \
+        echo "${QEMU_SHA256}  qemu-${QEMU_VERSION}.tar.xz" | sha256sum --check -; \
+        tar -xf "qemu-${QEMU_VERSION}.tar.xz"; \
     else \
         echo "Unknown QEMU_SOURCE: $QEMU_SOURCE"; exit 1; \
     fi
@@ -48,12 +56,15 @@ USER qemu-user
 ARG acpi_tables_dump_loc='\n\n    int fd = open("\/output\/'"${ACPI_TABLES_NAME}"'", O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);\n    if(fd != -1) {\n        int ret = write(fd, (uint8_t *)tables.table_data->data, tables.table_data->len);\n        if (ret < tables.table_data->len) {\n            printf("Error: Failed to write the acpi tables\\n");\n        } else {\n            printf("Successfully wrote the acpi tables to the file \\"'"${ACPI_TABLES_NAME}"'\\"\\n");\n        }\n    } else {\n        printf("Error: Failed to create acpi_tables file.\\n");\n    }\n    exit(0);'
 ARG acpi_build_c="hw/i386/acpi-build.c"
 ARG acpi_common_c="hw/i386/acpi-common.c"
+ARG q35_c="hw/pci-host/q35.c"
 ARG meson_build="meson.build"
 
 # The subdir('tests') reference moved inside an `if want_tools` block in QEMU 10.x and is now indented;
 # match optional leading whitespace so both layouts get commented out alongside subdir('pc-bios').
 RUN perl -i -0pe 's/(acpi_build_update\(void \*build_opaque\)[\s\S]*?acpi_build\([^;]*;)/\1'"$acpi_tables_dump_loc"'/gs' "$acpi_build_c" && \
     perl -i -pe 's/x86ms->eoi_intercept_unsupported;/1;/g' "$acpi_build_c" "$acpi_common_c" && \
+    perl -i -0pe 's/(static uint64_t q35_host_get_pci_hole64_start_value\(Object \*obj\)\n\{)/\1\n    const char *override = getenv("TDX_MEASURE_PCI_HOLE64_START");\n    if (override != NULL) { return strtoull(override, NULL, 0); }/s' "$q35_c" && \
+    perl -i -0pe 's/(hole64_end = ROUND_UP\(hole64_start \+ s->mch\.pci_hole64_size, 1ULL << 30\);)/\1\n    const char *end_override = getenv("TDX_MEASURE_PCI_HOLE64_END");\n    if (end_override != NULL) { value = strtoull(end_override, NULL, 0); visit_type_uint64(v, name, \&value, errp); return; }\n    if (getenv("TDX_MEASURE_PCI_HOLE64_START") != NULL) { value = hole64_end; visit_type_uint64(v, name, \&value, errp); return; }/s' "$q35_c" && \
     perl -i -pe "s/^(\s*)(subdir\('pc-bios'\)|subdir\('tests'\))/\$1# \$2/g" "$meson_build"
 
 # Configure QEMU with minimal features to reduce build time and image size - only KVM acceleration is needed for ACPI table generation

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Create `metadata.json` file with the below metadata:
 
 - `qemu` *(optional)*: Generic QEMU shape descriptor consumed by `--create-acpi-tables`. Each field is a thin pass-through to QEMU. When present, the QEMU command is built from this block plus a minimal set of measurement-related core flags (`-smp ... -m ... -bios ... -nodefaults -vga none -nographic -no-reboot`). When absent, the tool falls back to the Canonical direct-boot args. Fields:
   - `machine` *(required when block is present)*: value passed verbatim to `-machine`, e.g. `"q35,kernel_irqchip=split,memory-backend=mem0,smm=off,pic=off"`.
+  - `pci_hole64_start` *(optional)*: deterministic 64-bit PCI aperture start used only by the patched ACPI dumper. This reproduces the window that live VFIO BARs would establish without requiring those host devices during offline generation.
+  - `pci_hole64_end` *(optional)*: exclusive end of that aperture. Set this when VFIO BAR sizing expands the window beyond the configured `pci-hole64-size`.
   - `cpu` *(optional, default `"host"`)*: value passed verbatim to `-cpu`. Use a named model with an explicit `phys-bits=N` (e.g. `"Skylake-Server,phys-bits=46"`) to make the run independent of the host CPU.
   - `accel` *(optional, default `"kvm"`)*: value passed verbatim to `-accel`. Use `"tcg"` to skip KVM (CI runners without `/dev/kvm`, ARM hosts via x86 emulation, …).
   - `globals`: list of strings, each emitted as `-global <value>`.
@@ -108,7 +110,7 @@ These are calculated by the tool automatically.
 
 When `--create-acpi-tables` is passed, the tool builds a small Docker image that
 patches QEMU to dump `etc/acpi/tables` and exits before TD entry. This requires
-a working `docker` (with buildx) and, when `accel: "kvm"` is in effect, KVM on
+a working `docker` and, when `accel: "kvm"` is in effect, KVM on
 the host. Each supported distribution pins a known-good QEMU source version
 (`1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2` for `ubuntu:25.04`, `1:10.2.1+ds-1ubuntu4`
 for `ubuntu:26.04`) so the same metadata + CLI produces the same ACPI bytes
@@ -121,7 +123,13 @@ main archive:
 --create-acpi-tables ubuntu:26.04                              # default pin
 --create-acpi-tables ubuntu:26.04 1:10.2.1+ds-1ubuntu5         # explicit version
 --create-acpi-tables ubuntu:26.04 ""                           # current main-archive tip
+--create-acpi-tables qemu:10.1.0                              # pinned upstream release
 ```
+
+The `qemu:10.1.0` target downloads the upstream release tarball, verifies its
+pinned SHA-256 checksum, and builds it on the pinned Ubuntu 26.04 base image.
+This is useful when the measured deployment runs upstream QEMU rather than an
+Ubuntu source package.
 
 ### Indirect Boot
 

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -327,29 +327,44 @@ struct QemuPkg<'a> {
     version: &'a str,
     /// Immutable OCI digest of the base image (`sha256:...`).
     image_digest: &'static str,
+    base_image: &'static str,
+    source_checksum: &'static str,
 }
 
 fn qemu_pkg_for<'a>(distribution: &str, version_override: Option<&'a str>) -> Result<QemuPkg<'a>> {
     // Pinned defaults for reproducibility; override via `--qemu-version`.
-    let (source, default_version, image_digest): (&'static str, &'static str, &'static str) = match distribution {
+    let (source, default_version, base_image, image_digest, source_checksum): (&'static str, &'static str, &'static str, &'static str, &'static str) = match distribution {
         "ubuntu:25.04" => (
             "ppa",
             "1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2",
+            "ubuntu:25.04",
             "sha256:27771fb7b40a58237c98e8d3e6b9ecdd9289cec69a857fccfb85ff36294dac20",
+            "",
         ),
         "ubuntu:26.04" => (
             "main",
             "1:10.2.1+ds-1ubuntu4",
+            "ubuntu:26.04",
             "sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64",
+            "",
+        ),
+        "qemu:10.1.0" => (
+            "upstream",
+            "10.1.0",
+            "ubuntu:26.04",
+            "sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64",
+            "e0517349b50ca73ebec2fa85b06050d5c463ca65c738833bd8fc1f15f180be51",
         ),
         other => bail!(
-            "Unsupported distribution: {other}. Supported: ubuntu:25.04, ubuntu:26.04"
+            "Unsupported distribution: {other}. Supported: ubuntu:25.04, ubuntu:26.04, qemu:10.1.0"
         ),
     };
     Ok(QemuPkg {
         source,
         version: version_override.unwrap_or(default_version),
         image_digest,
+        base_image,
+        source_checksum,
     })
 }
 
@@ -442,13 +457,14 @@ fn build_docker_image(
         ),
     }
 
-    let pinned_image = format!("{distribution}@{}", pkg.image_digest);
+    let pinned_image = format!("{}@{}", pkg.base_image, pkg.image_digest);
     let status = Command::new("docker")
         .arg("build")
-        .args(["--progress", "plain", "--tag", IMAGE_NAME])
+        .args(["--tag", IMAGE_NAME])
         .arg("--build-arg").arg(format!("DISTRIBUTION={pinned_image}"))
         .arg("--build-arg").arg(format!("QEMU_SOURCE={}", pkg.source))
         .arg("--build-arg").arg(format!("QEMU_VERSION={}", pkg.version))
+        .arg("--build-arg").arg(format!("QEMU_SHA256={}", pkg.source_checksum))
         .arg("--build-arg").arg(format!("ACPI_TABLES_NAME={acpi_tables_name}"))
         .arg("--file").arg(dockerfile_dir.join("Dockerfile.qemu-acpi-dump"))
         .arg(dockerfile_dir)
@@ -466,6 +482,8 @@ fn run_docker_container(
     qemu_args: &[OsString],
     need_kvm: bool,
     need_vhost_vsock: bool,
+    pci_hole64_start: Option<&str>,
+    pci_hole64_end: Option<&str>,
 ) -> Result<()> {
     info!("Running QEMU container to generate ACPI tables...");
     // The Dockerfile skips `subdir('pc-bios')` in QEMU's meson build (the option
@@ -497,6 +515,12 @@ fn run_docker_container(
     }
     if need_vhost_vsock && Path::new("/dev/vhost-vsock").exists() {
         cmd.args(["--device", "/dev/vhost-vsock:/dev/vhost-vsock"]);
+    }
+    if let Some(start) = pci_hole64_start {
+        cmd.args(["--env", &format!("TDX_MEASURE_PCI_HOLE64_START={start}")]);
+    }
+    if let Some(end) = pci_hole64_end {
+        cmd.args(["--env", &format!("TDX_MEASURE_PCI_HOLE64_END={end}")]);
     }
     cmd.arg("-v").arg(format!("{}:{OVMF_IN_CONTAINER}:ro", bios.display()));
     cmd.arg("-v").arg(format!("{}:/output", output_dir.display()));
@@ -573,7 +597,15 @@ pub fn generate_acpi_tables(
         .unwrap_or(true);
     let need_vhost_vsock = boot_config.qemu.is_some();
 
-    run_docker_container(&bios, output_dir.path(), &qemu_args, need_kvm, need_vhost_vsock)?;
+    run_docker_container(
+        &bios,
+        output_dir.path(),
+        &qemu_args,
+        need_kvm,
+        need_vhost_vsock,
+        boot_config.qemu.as_ref().and_then(|q| q.pci_hole64_start.as_deref()),
+        boot_config.qemu.as_ref().and_then(|q| q.pci_hole64_end.as_deref()),
+    )?;
 
     // Move the produced ACPI tables into place; `fs::copy` would inherit the
     // container's restrictive 0600 from the source, so widen to 0644 after.
@@ -855,6 +887,8 @@ mod tests {
     fn build_qemu_args_qemu_block_passes_fields_verbatim_and_in_documented_order() {
         let shape = QemuShape {
             machine: "q35,kernel_irqchip=split,smm=off,pic=off".into(),
+            pci_hole64_start: None,
+            pci_hole64_end: None,
             cpu: "Skylake-Server,phys-bits=46".into(),
             accel: "tcg".into(),
             globals: vec!["q35-pcihost.pci-hole64-size=4096G".into()],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,10 @@ pub struct BootConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QemuShape {
     pub machine: String,
+    /// Optional deterministic replacement for the VFIO-derived 64-bit PCI
+    /// aperture start used by the patched ACPI dumper.
+    pub pci_hole64_start: Option<String>,
+    pub pci_hole64_end: Option<String>,
     #[serde(default = "default_cpu")]
     pub cpu: String,
     #[serde(default = "default_accel")]

--- a/tests/fixtures/q35-with-hpet/metadata.json
+++ b/tests/fixtures/q35-with-hpet/metadata.json
@@ -6,6 +6,8 @@
         "acpi_tables": "acpi_tables.bin",
         "qemu": {
             "machine": "q35,kernel_irqchip=split,memory-backend=mem0,smm=off,pic=off",
+            "pci_hole64_start": null,
+            "pci_hole64_end": null,
             "cpu": "Skylake-Server,phys-bits=46",
             "accel": "tcg",
             "globals": [

--- a/tests/fixtures/runtime-capture/metadata.json
+++ b/tests/fixtures/runtime-capture/metadata.json
@@ -6,6 +6,8 @@
         "acpi_tables": "acpi_tables.bin",
         "qemu": {
             "machine": "q35,kernel_irqchip=split,memory-backend=mem0,smm=off,pic=off",
+            "pci_hole64_start": null,
+            "pci_hole64_end": null,
             "cpu": "Skylake-Server,phys-bits=46",
             "accel": "tcg",
             "globals": [


### PR DESCRIPTION
## Summary
- add a `qemu:10.1.0` ACPI generation target for deployments built from upstream QEMU releases
- verify the upstream QEMU tarball against its pinned SHA-256 checksum
- keep the build reproducible on the pinned Ubuntu 26.04 base image
- allow Docker installations without buildx by avoiding the buildx-only `--progress` flag

## Motivation
Tinfoil production hosts run upstream QEMU 10.1.0 rather than an Ubuntu QEMU source package. The generic `boot_config.qemu` support can reproduce their ACPI topology, but the generator also needs to build the exact upstream QEMU release to produce byte-identical tables.

## Validation
- `cargo test --lib`
- `cargo build --release --manifest-path cli/Cargo.toml`
- regenerated a production-captured 8 vCPU / 16 GiB / 3-disk ACPI table byte-for-byte using `--create-acpi-tables qemu:10.1.0`
