### PR TITLE
chore: sort Cargo manifests and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
         key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
           cargo-${{ runner.os }}-
+    - name: Check Cargo manifest sorting
+      # cargo-sort is not shipped with the toolchain, so it is installed here.
+      # Pinned so a new upstream release cannot turn a green PR red on its own.
+      # --locked keeps cargo-sort's own dependency resolution reproducible.
+      run: |
+        cargo install cargo-sort --version 2.1.4 --locked
+        cargo sort --check --workspace
     - name: Build CLI (release)
       run: cargo build --release
     - name: Upload CLI binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
+[package]
+name = "tdx-measure"
+description = "A library for calculating measurements of Intel TDX-protected VMs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
 [workspace]
 members = ["cli"]
 default-members = [".", "cli"]
@@ -13,27 +20,20 @@ fs-err = "3.2"
 hex = "0.4"
 serde_json = "1.0"
 
-[package]
-name = "tdx-measure"
-description = "A library for calculating measurements of Intel TDX-protected VMs"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
-
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json.workspace = true
-serde-human-bytes = "0.1"
-hex.workspace = true
-thiserror = "2.0"
-sha2 = "0.10"
 anyhow.workspace = true
-object = "0.38"
-hex-literal = "1.1"
-fs-err.workspace = true
 bon = "3.8"
+fs-err.workspace = true
+hex.workspace = true
+hex-literal = "1.1"
 log = "0.4"
+object = "0.38"
+serde = { version = "1.0", features = ["derive"] }
+serde-human-bytes = "0.1"
+serde_json.workspace = true
+sha2 = "0.10"
 tempfile = "3.27.0"
+thiserror = "2.0"
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,10 +10,10 @@ name = "tdx-measure"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
-tdx-measure = { path = ".." }
 anyhow.workspace = true
-hex.workspace = true
+clap = { version = "4.5", features = ["derive"] }
 fs-err.workspace = true
+hex.workspace = true
 serde_json.workspace = true
+tdx-measure = { path = ".." }
 tracing-subscriber = "0.3"


### PR DESCRIPTION
Sorts both `Cargo.toml` manifests with `cargo-sort` and adds a CI check so they stay sorted.

Now rebased onto `main` (post-#71), so the PR contains only its own two commits:

| commit |
|---|
| style: sort Cargo manifests with cargo-sort |
| ci: enforce sorted Cargo manifests |

The `chore: ignore the cargo-sort commit in git blame` commit has been dropped as requested — `.git-blame-ignore-revs` will be added in a separate PR once the final merge hashes are known.

### Why

`cargo-sort` gives the manifests a deterministic key order, so unrelated dependency additions stop producing noisy or conflicting diffs. The bulk reordering is mechanical, so it is isolated in its own commit.

The CI step pins `cargo-sort` to 2.1.4 and installs it with `--locked`: the tool is not part of the toolchain, and an unpinned upstream release could otherwise turn a green PR red on its own.

### Verification

`cargo sort --check --workspace` and `cargo test --workspace` (11 passed, 1 Docker-gated ignore) both pass. No source files change; the diff is limited to manifest key order and the CI workflow.
