### PR TITLE
style: format Rust sources with cargo fmt and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
     - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+      with:
+        # The toolchain is installed with the minimal profile, so rustfmt has to be requested explicitly.
+        # Without this the fmt check below depends on the hosted image happening to ship it.
+        components: rustfmt
     - name: Cache cargo deps
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
@@ -45,6 +49,8 @@ jobs:
         key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
           cargo-${{ runner.os }}-
+    - name: Check Rust formatting
+      run: cargo fmt --all -- --check
     - name: Check Cargo manifest sorting
       # cargo-sort is not shipped with the toolchain, so it is installed here.
       # Pinned so a new upstream release cannot turn a green PR red on its own.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
-use tdx_measure::{Machine, ImageConfig};
 use fs_err as fs;
 use std::path::{Path, PathBuf};
+use tdx_measure::{ImageConfig, Machine};
 
 mod transcript;
 use transcript::generate_transcript;
@@ -80,7 +80,11 @@ struct PathStorage {
 }
 
 impl PathResolver {
-    fn new(metadata_path: &Path, image_config: &ImageConfig, require_boot_config: bool) -> Result<Self> {
+    fn new(
+        metadata_path: &Path,
+        image_config: &ImageConfig,
+        require_boot_config: bool,
+    ) -> Result<Self> {
         let parent_dir = metadata_path.parent().unwrap_or(".".as_ref());
 
         // Handle optional boot_config
@@ -90,23 +94,54 @@ impl PathResolver {
                 memory_size: image_config.memory_size()?,
                 firmware: parent_dir.join(&boot_config.bios).display().to_string(),
                 cmdline: image_config.cmdline().to_string(),
-                acpi_tables: parent_dir.join(&boot_config.acpi_tables).display().to_string(),
-                rsdp: boot_config.rsdp.as_ref().map(|p| parent_dir.join(p).display().to_string()),
-                table_loader: boot_config.table_loader.as_ref().map(|p| parent_dir.join(p).display().to_string()),
-                boot_order: boot_config.boot_order.as_ref().map(|p| parent_dir.join(p).display().to_string()),
-                path_boot_xxxx: boot_config.path_boot_xxxx.as_ref().map(|p| parent_dir.join(p).display().to_string()),
-                kernel: image_config.direct_boot().map(|d| parent_dir.join(&d.kernel).display().to_string()),
-                initrd: image_config.direct_boot().map(|d| parent_dir.join(&d.initrd).display().to_string()),
-                qcow2: image_config.indirect_boot().map(|i| parent_dir.join(&i.qcow2).display().to_string()),
-                mok_list: image_config.indirect_boot().map(|i| parent_dir.join(&i.mok_list).display().to_string()),
-                mok_list_trusted: image_config.indirect_boot().map(|i| parent_dir.join(&i.mok_list_trusted).display().to_string()),
-                mok_list_x: image_config.indirect_boot().map(|i| parent_dir.join(&i.mok_list_x).display().to_string()),
-                sbat_level: image_config.indirect_boot().map(|i| parent_dir.join(&i.sbat_level).display().to_string()),
+                acpi_tables: parent_dir
+                    .join(&boot_config.acpi_tables)
+                    .display()
+                    .to_string(),
+                rsdp: boot_config
+                    .rsdp
+                    .as_ref()
+                    .map(|p| parent_dir.join(p).display().to_string()),
+                table_loader: boot_config
+                    .table_loader
+                    .as_ref()
+                    .map(|p| parent_dir.join(p).display().to_string()),
+                boot_order: boot_config
+                    .boot_order
+                    .as_ref()
+                    .map(|p| parent_dir.join(p).display().to_string()),
+                path_boot_xxxx: boot_config
+                    .path_boot_xxxx
+                    .as_ref()
+                    .map(|p| parent_dir.join(p).display().to_string()),
+                kernel: image_config
+                    .direct_boot()
+                    .map(|d| parent_dir.join(&d.kernel).display().to_string()),
+                initrd: image_config
+                    .direct_boot()
+                    .map(|d| parent_dir.join(&d.initrd).display().to_string()),
+                qcow2: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.qcow2).display().to_string()),
+                mok_list: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.mok_list).display().to_string()),
+                mok_list_trusted: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.mok_list_trusted).display().to_string()),
+                mok_list_x: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.mok_list_x).display().to_string()),
+                sbat_level: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.sbat_level).display().to_string()),
             }
         } else {
             // When boot_config is None (runtime-only mode), provide empty strings for platform fields
             if require_boot_config {
-                return Err(anyhow!("Boot info is required but not provided in the configuration"));
+                return Err(anyhow!(
+                    "Boot info is required but not provided in the configuration"
+                ));
             }
             PathStorage {
                 cpu_count: 0,
@@ -118,13 +153,27 @@ impl PathResolver {
                 table_loader: None,
                 boot_order: None,
                 path_boot_xxxx: None,
-                kernel: image_config.direct_boot().map(|d| parent_dir.join(&d.kernel).display().to_string()),
-                initrd: image_config.direct_boot().map(|d| parent_dir.join(&d.initrd).display().to_string()),
-                qcow2: image_config.indirect_boot().map(|i| parent_dir.join(&i.qcow2).display().to_string()),
-                mok_list: image_config.indirect_boot().map(|i| parent_dir.join(&i.mok_list).display().to_string()),
-                mok_list_trusted: image_config.indirect_boot().map(|i| parent_dir.join(&i.mok_list_trusted).display().to_string()),
-                mok_list_x: image_config.indirect_boot().map(|i| parent_dir.join(&i.mok_list_x).display().to_string()),
-                sbat_level: image_config.indirect_boot().map(|i| parent_dir.join(&i.sbat_level).display().to_string()),
+                kernel: image_config
+                    .direct_boot()
+                    .map(|d| parent_dir.join(&d.kernel).display().to_string()),
+                initrd: image_config
+                    .direct_boot()
+                    .map(|d| parent_dir.join(&d.initrd).display().to_string()),
+                qcow2: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.qcow2).display().to_string()),
+                mok_list: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.mok_list).display().to_string()),
+                mok_list_trusted: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.mok_list_trusted).display().to_string()),
+                mok_list_x: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.mok_list_x).display().to_string()),
+                sbat_level: image_config
+                    .indirect_boot()
+                    .map(|i| parent_dir.join(&i.sbat_level).display().to_string()),
             }
         };
 
@@ -167,7 +216,8 @@ impl PathResolver {
 
 fn process_measurements(config: &Cli, image_config: &ImageConfig) -> Result<()> {
     // Validate the configuration
-    image_config.validate()
+    image_config
+        .validate()
         .map_err(|e| anyhow!("Invalid image configuration: {}", e))?;
 
     // Determine boot mode: CLI flag overrides JSON configuration, defaults to direct boot
@@ -180,9 +230,21 @@ fn process_measurements(config: &Cli, image_config: &ImageConfig) -> Result<()> 
 
     // Validate boot mode configuration (skip validation for platform-only mode)
     if !config.platform_only {
-        match (direct_boot, image_config.direct_boot(), image_config.indirect_boot()) {
-            (true, None, _) => return Err(anyhow!("Direct boot mode specified but no direct boot configuration found in JSON")),
-            (false, _, None) => return Err(anyhow!("Indirect boot mode specified but no indirect boot configuration found in JSON")),
+        match (
+            direct_boot,
+            image_config.direct_boot(),
+            image_config.indirect_boot(),
+        ) {
+            (true, None, _) => {
+                return Err(anyhow!(
+                    "Direct boot mode specified but no direct boot configuration found in JSON"
+                ))
+            }
+            (false, _, None) => {
+                return Err(anyhow!(
+                    "Indirect boot mode specified but no indirect boot configuration found in JSON"
+                ))
+            }
             _ => {}
         }
     }
@@ -230,19 +292,33 @@ fn process_measurements(config: &Cli, image_config: &ImageConfig) -> Result<()> 
 
     // Measure
     let measurements = if config.platform_only {
-        machine.measure_platform().context("Failed to measure platform")?
+        machine
+            .measure_platform()
+            .context("Failed to measure platform")?
     } else if config.runtime_only {
         if create_acpi_table {
-            eprintln!("--create-acpi-tables is not required with --runtime-only and will be ignored");
+            eprintln!(
+                "--create-acpi-tables is not required with --runtime-only and will be ignored"
+            );
         }
-        machine.measure_runtime().context("Failed to measure runtime")?
+        machine
+            .measure_runtime()
+            .context("Failed to measure runtime")?
     } else {
-        machine.measure().context("Failed to measure machine configuration")?
+        machine
+            .measure()
+            .context("Failed to measure machine configuration")?
     };
 
     // Generate transcript (if requested).
     if let Some(ref transcript_file) = config.transcript {
-        generate_transcript(transcript_file, &path_resolver, direct_boot, config.platform_only, config.runtime_only)?;
+        generate_transcript(
+            transcript_file,
+            &path_resolver,
+            direct_boot,
+            config.platform_only,
+            config.runtime_only,
+        )?;
     }
 
     // Output results
@@ -265,8 +341,7 @@ fn output_measurements(config: &Cli, measurements: &tdx_measure::TdxMeasurements
     }
 
     if let Some(ref json_file) = config.json_file {
-        fs::write(json_file, json_output)
-            .context("Failed to write measurements to file")?;
+        fs::write(json_file, json_output).context("Failed to write measurements to file")?;
     }
 
     Ok(())
@@ -276,10 +351,9 @@ fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let cli = Cli::parse();
-    let metadata = fs::read_to_string(&cli.metadata)
-        .context("Failed to read image metadata")?;
-    let image_config: ImageConfig = serde_json::from_str(&metadata)
-        .context("Failed to parse image metadata")?;
+    let metadata = fs::read_to_string(&cli.metadata).context("Failed to read image metadata")?;
+    let image_config: ImageConfig =
+        serde_json::from_str(&metadata).context("Failed to parse image metadata")?;
 
     process_measurements(&cli, &image_config)?;
 

--- a/cli/src/transcript.rs
+++ b/cli/src/transcript.rs
@@ -3,16 +3,21 @@
  * Copyright (c) 2025 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-use std::io::Write;
-use std::process::Command;
-use anyhow::{Context, Result, anyhow};
-use fs_err as fs;
-use std::path::Path;
 use crate::{PathResolver, PathStorage};
+use anyhow::{anyhow, Context, Result};
+use fs_err as fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
 
 /// Generate a human-readable transcript of metadata files
-pub fn generate_transcript(output_file: &Path, path_resolver: &PathResolver, direct_boot: bool, platform_only: bool, runtime_only: bool) -> Result<()> {
-
+pub fn generate_transcript(
+    output_file: &Path,
+    path_resolver: &PathResolver,
+    direct_boot: bool,
+    platform_only: bool,
+    runtime_only: bool,
+) -> Result<()> {
     let mut output = Vec::new();
 
     writeln!(output, "=== TDX Metadata Transcript ===").unwrap();
@@ -76,11 +81,19 @@ fn split_acpi_tables(data: &[u8]) -> Result<Vec<AcpiTableInfo>> {
         }
 
         // Read signature (4 bytes)
-        let signature_bytes = [data[offset], data[offset + 1], data[offset + 2], data[offset + 3]];
+        let signature_bytes = [
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ];
 
         // Read length (4 bytes, little-endian)
         let length = u32::from_le_bytes([
-            data[offset + 4], data[offset + 5], data[offset + 6], data[offset + 7]
+            data[offset + 4],
+            data[offset + 5],
+            data[offset + 6],
+            data[offset + 7],
         ]);
 
         // Validate length
@@ -90,7 +103,10 @@ fn split_acpi_tables(data: &[u8]) -> Result<Vec<AcpiTableInfo>> {
         }
 
         if offset + length as usize > data.len() {
-            eprintln!("Warning: Table length {} exceeds remaining data at offset {}, skipping", length, offset);
+            eprintln!(
+                "Warning: Table length {} exceeds remaining data at offset {}, skipping",
+                length, offset
+            );
             offset += 1;
             continue;
         }
@@ -99,7 +115,10 @@ fn split_acpi_tables(data: &[u8]) -> Result<Vec<AcpiTableInfo>> {
         let signature = match std::str::from_utf8(&signature_bytes) {
             Ok(s) if is_valid_acpi_signature(&signature_bytes) => s.to_string(),
             _ => {
-                eprintln!("Warning: Invalid signature at offset {}: {:02x?}, searching for next table", offset, signature_bytes);
+                eprintln!(
+                    "Warning: Invalid signature at offset {}: {:02x?}, searching for next table",
+                    offset, signature_bytes
+                );
                 offset += 1;
                 continue;
             }
@@ -114,7 +133,10 @@ fn split_acpi_tables(data: &[u8]) -> Result<Vec<AcpiTableInfo>> {
             data: table_data,
         });
 
-        eprintln!("Found ACPI table: {} ({} bytes) at offset {}", signature, length, offset);
+        eprintln!(
+            "Found ACPI table: {} ({} bytes) at offset {}",
+            signature, length, offset
+        );
 
         // Move to the next table (no alignment padding, just exact length)
         offset += length as usize;
@@ -132,13 +154,15 @@ fn split_acpi_tables(data: &[u8]) -> Result<Vec<AcpiTableInfo>> {
 fn write_acpi_tables_with_iasl(output: &mut Vec<u8>, acpi_tables_path: &str) -> Result<()> {
     writeln!(output, "=== ACPI Tables ===").unwrap();
     writeln!(output, "Source: QEMU fw_cfg concatenated ACPI tables dump").unwrap();
-    writeln!(output, "Disassembled using Intel ACPI Source Language Compiler (iasl)").unwrap();
+    writeln!(
+        output,
+        "Disassembled using Intel ACPI Source Language Compiler (iasl)"
+    )
+    .unwrap();
     writeln!(output).unwrap();
 
     // Check if iasl is available
-    let iasl_check = Command::new("iasl")
-        .arg("-h")
-        .output();
+    let iasl_check = Command::new("iasl").arg("-h").output();
 
     if iasl_check.is_err() {
         writeln!(output, "WARNING: iasl tool not found. Install acpica-tools package for detailed ACPI analysis.").unwrap();
@@ -172,7 +196,14 @@ fn write_acpi_tables_with_iasl(output: &mut Vec<u8>, acpi_tables_path: &str) -> 
     }
 
     for (signature, count) in &signature_counts {
-        writeln!(output, "  {}: {} table{}", signature, count, if *count > 1 { "s" } else { "" }).unwrap();
+        writeln!(
+            output,
+            "  {}: {} table{}",
+            signature,
+            count,
+            if *count > 1 { "s" } else { "" }
+        )
+        .unwrap();
     }
     writeln!(output).unwrap();
 
@@ -183,7 +214,14 @@ fn write_acpi_tables_with_iasl(output: &mut Vec<u8>, acpi_tables_path: &str) -> 
 
     // Process each table with iasl
     for (i, table) in tables.iter().enumerate() {
-        writeln!(output, "=== Table {}: {} ({} bytes) ===", i + 1, table.signature, table.length).unwrap();
+        writeln!(
+            output,
+            "=== Table {}: {} ({} bytes) ===",
+            i + 1,
+            table.signature,
+            table.length
+        )
+        .unwrap();
 
         // Generate unique filename for duplicate signatures
         let table_filename = if signature_counts[&table.signature] > 1 {
@@ -198,7 +236,7 @@ fn write_acpi_tables_with_iasl(output: &mut Vec<u8>, acpi_tables_path: &str) -> 
 
         // Run iasl on this specific table
         let iasl_output = Command::new("iasl")
-            .arg("-d")  // Disassemble
+            .arg("-d") // Disassemble
             .arg(&temp_table_file)
             .current_dir(&temp_dir)
             .output()
@@ -230,11 +268,21 @@ fn write_acpi_tables_with_iasl(output: &mut Vec<u8>, acpi_tables_path: &str) -> 
                     writeln!(output, "---").unwrap();
                 }
                 Err(e) => {
-                    writeln!(output, "Error reading disassembled {} table: {}", table.signature, e).unwrap();
+                    writeln!(
+                        output,
+                        "Error reading disassembled {} table: {}",
+                        table.signature, e
+                    )
+                    .unwrap();
                 }
             }
         } else {
-            writeln!(output, "No .dsl file generated for {} table. Raw hex dump:", table.signature).unwrap();
+            writeln!(
+                output,
+                "No .dsl file generated for {} table. Raw hex dump:",
+                table.signature
+            )
+            .unwrap();
             write_raw_table_hex_dump(output, &table.data, &table.signature)?;
         }
 
@@ -243,7 +291,11 @@ fn write_acpi_tables_with_iasl(output: &mut Vec<u8>, acpi_tables_path: &str) -> 
 
     // Clean up temporary directory
     if let Err(e) = fs::remove_dir_all(&temp_dir) {
-        eprintln!("Warning: Failed to clean up temp directory {}: {}", temp_dir.display(), e);
+        eprintln!(
+            "Warning: Failed to clean up temp directory {}: {}",
+            temp_dir.display(),
+            e
+        );
     }
 
     Ok(())
@@ -251,7 +303,13 @@ fn write_acpi_tables_with_iasl(output: &mut Vec<u8>, acpi_tables_path: &str) -> 
 
 /// Write raw table data as hex dump
 fn write_raw_table_hex_dump(output: &mut Vec<u8>, data: &[u8], table_name: &str) -> Result<()> {
-    writeln!(output, "{} table raw data ({} bytes):", table_name, data.len()).unwrap();
+    writeln!(
+        output,
+        "{} table raw data ({} bytes):",
+        table_name,
+        data.len()
+    )
+    .unwrap();
 
     let display_bytes = std::cmp::min(data.len(), 256);
 
@@ -297,7 +355,6 @@ fn write_raw_table_hex_dump(output: &mut Vec<u8>, data: &[u8], table_name: &str)
 
 // Print UEFI boot variables
 // Specification can be found at https://uefi.org/specs/UEFI/2.10/03_Boot_Manager.html
-
 
 /// EFI_LOAD_OPTION structure representing a UEFI boot option
 #[derive(Debug)]
@@ -391,8 +448,12 @@ fn format_device_path(path: &DevicePath) -> String {
         DEVICE_PATH_TYPE_MEDIA => format_media_device_path(path),
         DEVICE_PATH_TYPE_BIOS_BOOT => format_bios_boot_device_path(path),
         DEVICE_PATH_TYPE_END => "End".to_string(),
-        _ => format!("Unknown(Type={}, SubType={}, {} bytes)",
-                    path.path_type, path.sub_type, path.data.len()),
+        _ => format!(
+            "Unknown(Type={}, SubType={}, {} bytes)",
+            path.path_type,
+            path.sub_type,
+            path.data.len()
+        ),
     }
 }
 
@@ -408,7 +469,11 @@ fn format_hardware_device_path(path: &DevicePath) -> String {
                 "PCI(Invalid)".to_string()
             }
         }
-        _ => format!("Hardware(SubType={}, {} bytes)", path.sub_type, path.data.len()),
+        _ => format!(
+            "Hardware(SubType={}, {} bytes)",
+            path.sub_type,
+            path.data.len()
+        ),
     }
 }
 
@@ -417,8 +482,10 @@ fn format_acpi_device_path(path: &DevicePath) -> String {
     match path.sub_type {
         DEVICE_PATH_SUBTYPE_ACPI => {
             if path.data.len() >= 8 {
-                let hid = u32::from_le_bytes([path.data[0], path.data[1], path.data[2], path.data[3]]);
-                let uid = u32::from_le_bytes([path.data[4], path.data[5], path.data[6], path.data[7]]);
+                let hid =
+                    u32::from_le_bytes([path.data[0], path.data[1], path.data[2], path.data[3]]);
+                let uid =
+                    u32::from_le_bytes([path.data[4], path.data[5], path.data[6], path.data[7]]);
                 format!("ACPI(HID=0x{:08X},UID=0x{:08X})", hid, uid)
             } else {
                 "ACPI(Invalid)".to_string()
@@ -430,7 +497,11 @@ fn format_acpi_device_path(path: &DevicePath) -> String {
 
 /// Format messaging device path
 fn format_messaging_device_path(path: &DevicePath) -> String {
-    format!("Messaging(SubType={}, {} bytes)", path.sub_type, path.data.len())
+    format!(
+        "Messaging(SubType={}, {} bytes)",
+        path.sub_type,
+        path.data.len()
+    )
 }
 
 /// Format media device path
@@ -438,14 +509,27 @@ fn format_media_device_path(path: &DevicePath) -> String {
     match path.sub_type {
         DEVICE_PATH_SUBTYPE_HARD_DRIVE => {
             if path.data.len() >= 42 {
-                let partition_number = u32::from_le_bytes([path.data[0], path.data[1], path.data[2], path.data[3]]);
+                let partition_number =
+                    u32::from_le_bytes([path.data[0], path.data[1], path.data[2], path.data[3]]);
                 let partition_start = u64::from_le_bytes([
-                    path.data[4], path.data[5], path.data[6], path.data[7],
-                    path.data[8], path.data[9], path.data[10], path.data[11]
+                    path.data[4],
+                    path.data[5],
+                    path.data[6],
+                    path.data[7],
+                    path.data[8],
+                    path.data[9],
+                    path.data[10],
+                    path.data[11],
                 ]);
                 let partition_size = u64::from_le_bytes([
-                    path.data[12], path.data[13], path.data[14], path.data[15],
-                    path.data[16], path.data[17], path.data[18], path.data[19]
+                    path.data[12],
+                    path.data[13],
+                    path.data[14],
+                    path.data[15],
+                    path.data[16],
+                    path.data[17],
+                    path.data[18],
+                    path.data[19],
                 ]);
                 let signature_type = path.data[41];
                 let signature_type_str = match signature_type {
@@ -454,8 +538,10 @@ fn format_media_device_path(path: &DevicePath) -> String {
                     0x02 => "GPT",
                     _ => "Unknown",
                 };
-                format!("HD(Part={},Sig={},Start=0x{:X},Size=0x{:X})",
-                       partition_number, signature_type_str, partition_start, partition_size)
+                format!(
+                    "HD(Part={},Sig={},Start=0x{:X},Size=0x{:X})",
+                    partition_number, signature_type_str, partition_start, partition_size
+                )
             } else {
                 "HD(Invalid)".to_string()
             }
@@ -463,7 +549,9 @@ fn format_media_device_path(path: &DevicePath) -> String {
         DEVICE_PATH_SUBTYPE_FILE_PATH => {
             if !path.data.is_empty() {
                 // File path is UTF-16 encoded
-                let utf16_chars: Vec<u16> = path.data.chunks(2)
+                let utf16_chars: Vec<u16> = path
+                    .data
+                    .chunks(2)
                     .filter_map(|chunk| {
                         if chunk.len() == 2 {
                             Some(u16::from_le_bytes([chunk[0], chunk[1]]))
@@ -482,7 +570,11 @@ fn format_media_device_path(path: &DevicePath) -> String {
                 "File(Empty)".to_string()
             }
         }
-        _ => format!("Media(SubType={}, {} bytes)", path.sub_type, path.data.len()),
+        _ => format!(
+            "Media(SubType={}, {} bytes)",
+            path.sub_type,
+            path.data.len()
+        ),
     }
 }
 
@@ -498,7 +590,8 @@ fn format_device_path_list(data: &[u8]) -> String {
             if paths.is_empty() {
                 "[Empty]".to_string()
             } else {
-                paths.iter()
+                paths
+                    .iter()
                     .map(format_device_path)
                     .collect::<Vec<_>>()
                     .join("/")
@@ -511,7 +604,10 @@ fn format_device_path_list(data: &[u8]) -> String {
 /// Parse BootOrder variable (array of UINT16 values in little-endian)
 fn parse_boot_order(data: &[u8]) -> Result<Vec<u16>> {
     if data.len() % 2 != 0 {
-        return Err(anyhow!("BootOrder data length must be even (got {} bytes)", data.len()));
+        return Err(anyhow!(
+            "BootOrder data length must be even (got {} bytes)",
+            data.len()
+        ));
     }
 
     let mut boot_order = Vec::new();
@@ -526,7 +622,10 @@ fn parse_boot_order(data: &[u8]) -> Result<Vec<u16>> {
 /// Parse Boot#### variable (EFI_LOAD_OPTION structure)
 fn parse_boot_option(data: &[u8]) -> Result<EfiLoadOption> {
     if data.len() < 6 {
-        return Err(anyhow!("Boot option data too short (need at least 6 bytes, got {})", data.len()));
+        return Err(anyhow!(
+            "Boot option data too short (need at least 6 bytes, got {})",
+            data.len()
+        ));
     }
 
     // Parse fixed header (6 bytes)
@@ -559,8 +658,11 @@ fn parse_boot_option(data: &[u8]) -> Result<EfiLoadOption> {
     let file_path_list = if file_path_end <= data.len() {
         data[offset..file_path_end].to_vec()
     } else {
-        return Err(anyhow!("File path list extends beyond data (need {} bytes, have {})",
-                          file_path_end, data.len()));
+        return Err(anyhow!(
+            "File path list extends beyond data (need {} bytes, have {})",
+            file_path_end,
+            data.len()
+        ));
     };
 
     offset = file_path_end;
@@ -610,14 +712,30 @@ fn format_load_option_attributes(attributes: u32) -> String {
 }
 
 /// Write boot variables with pretty printing and hex dumps
-fn write_boot_variables(output: &mut Vec<u8>, paths: &PathStorage, direct_boot: bool) -> Result<()> {
+fn write_boot_variables(
+    output: &mut Vec<u8>,
+    paths: &PathStorage,
+    direct_boot: bool,
+) -> Result<()> {
     writeln!(output, "=== Boot Variables ===").unwrap();
-    writeln!(output, "These are UEFI boot variables that control the boot process.").unwrap();
-    writeln!(output, "Reference: UEFI Specification 2.10+ Chapter 3: Boot Manager").unwrap();
+    writeln!(
+        output,
+        "These are UEFI boot variables that control the boot process."
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "Reference: UEFI Specification 2.10+ Chapter 3: Boot Manager"
+    )
+    .unwrap();
     writeln!(output).unwrap();
 
     // Parse and display BootOrder
-    let boot_entries = write_boot_order_analysis(output, &paths.boot_order.as_deref().unwrap_or(""), direct_boot)?;
+    let boot_entries = write_boot_order_analysis(
+        output,
+        &paths.boot_order.as_deref().unwrap_or(""),
+        direct_boot,
+    )?;
 
     // Parse and display Boot#### variables
 
@@ -629,7 +747,11 @@ fn write_boot_variables(output: &mut Vec<u8>, paths: &PathStorage, direct_boot: 
     } else {
         for boot_entry in boot_entries {
             let name = format!("Boot{:04X}", boot_entry);
-            let path = format!("{}/{}.bin", paths.path_boot_xxxx.as_deref().unwrap_or(""), name);
+            let path = format!(
+                "{}/{}.bin",
+                paths.path_boot_xxxx.as_deref().unwrap_or(""),
+                name
+            );
             let data = fs::read(&path)
                 .with_context(|| format!("Failed to read {} from {}", name, path))?;
             write_boot_option_analysis(output, &name, &data)?;
@@ -640,7 +762,11 @@ fn write_boot_variables(output: &mut Vec<u8>, paths: &PathStorage, direct_boot: 
 }
 
 /// Write BootOrder analysis with pretty printing
-fn write_boot_order_analysis(output: &mut Vec<u8>, boot_order_path: &str, direct_boot: bool) -> Result<Vec<u16>> {
+fn write_boot_order_analysis(
+    output: &mut Vec<u8>,
+    boot_order_path: &str,
+    direct_boot: bool,
+) -> Result<Vec<u16>> {
     writeln!(output, "--- BootOrder Analysis ---").unwrap();
 
     let data = if direct_boot {
@@ -657,8 +783,16 @@ fn write_boot_order_analysis(output: &mut Vec<u8>, boot_order_path: &str, direct
             for (i, boot_num) in boot_order.iter().enumerate() {
                 writeln!(output, "  {}: Boot{:04X}", i + 1, boot_num).unwrap();
             }
-            writeln!(output, "Boot preference order: {}",
-                    boot_order.iter().map(|n| format!("Boot{:04X}", n)).collect::<Vec<_>>().join(" -> ")).unwrap();
+            writeln!(
+                output,
+                "Boot preference order: {}",
+                boot_order
+                    .iter()
+                    .map(|n| format!("Boot{:04X}", n))
+                    .collect::<Vec<_>>()
+                    .join(" -> ")
+            )
+            .unwrap();
             boot_order
         }
         Err(e) => {
@@ -693,10 +827,25 @@ fn write_boot_option_analysis(output: &mut Vec<u8>, name: &str, data: &[u8]) -> 
     match parse_boot_option(&data) {
         Ok(boot_option) => {
             writeln!(output, "EFI_LOAD_OPTION structure:").unwrap();
-            writeln!(output, "  Attributes: {}", format_load_option_attributes(boot_option.attributes)).unwrap();
-            writeln!(output, "  FilePathListLength: {} bytes", boot_option.file_path_list_length).unwrap();
+            writeln!(
+                output,
+                "  Attributes: {}",
+                format_load_option_attributes(boot_option.attributes)
+            )
+            .unwrap();
+            writeln!(
+                output,
+                "  FilePathListLength: {} bytes",
+                boot_option.file_path_list_length
+            )
+            .unwrap();
             writeln!(output, "  Description: \"{}\"", boot_option.description).unwrap();
-            writeln!(output, "  FilePathList: {} bytes", boot_option.file_path_list.len()).unwrap();
+            writeln!(
+                output,
+                "  FilePathList: {} bytes",
+                boot_option.file_path_list.len()
+            )
+            .unwrap();
 
             if !boot_option.file_path_list.is_empty() {
                 let device_path_str = format_device_path_list(&boot_option.file_path_list);
@@ -704,17 +853,35 @@ fn write_boot_option_analysis(output: &mut Vec<u8>, name: &str, data: &[u8]) -> 
             }
 
             if !boot_option.optional_data.is_empty() {
-                writeln!(output, "  OptionalData: {} bytes", boot_option.optional_data.len()).unwrap();
-                writeln!(output, "    OptionalData hex: {}",
-                        boot_option.optional_data.iter().map(|b| format!("{:02x}", b)).collect::<Vec<_>>().join(" ")).unwrap();
+                writeln!(
+                    output,
+                    "  OptionalData: {} bytes",
+                    boot_option.optional_data.len()
+                )
+                .unwrap();
+                writeln!(
+                    output,
+                    "    OptionalData hex: {}",
+                    boot_option
+                        .optional_data
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                )
+                .unwrap();
             }
 
             // Boot status summary
             let active = boot_option.attributes & LOAD_OPTION_ACTIVE != 0;
             let hidden = boot_option.attributes & LOAD_OPTION_HIDDEN != 0;
-            writeln!(output, "  Status: {} {}",
-                    if active { "ACTIVE" } else { "INACTIVE" },
-                    if hidden { "(HIDDEN)" } else { "(VISIBLE)" }).unwrap();
+            writeln!(
+                output,
+                "  Status: {} {}",
+                if active { "ACTIVE" } else { "INACTIVE" },
+                if hidden { "(HIDDEN)" } else { "(VISIBLE)" }
+            )
+            .unwrap();
         }
         Err(e) => {
             writeln!(output, "Failed to parse {} as EFI_LOAD_OPTION: {}", name, e).unwrap();
@@ -754,7 +921,11 @@ fn write_mok_variables(output: &mut Vec<u8>, paths: &PathStorage) -> Result<()> 
 /// Write SBAT level for indirect boot
 fn write_sbat_level(output: &mut Vec<u8>, paths: &PathStorage) -> Result<()> {
     writeln!(output, "=== SBAT Level ===").unwrap();
-    writeln!(output, "Secure Boot Advanced Targeting (SBAT) level information.").unwrap();
+    writeln!(
+        output,
+        "Secure Boot Advanced Targeting (SBAT) level information."
+    )
+    .unwrap();
     writeln!(output).unwrap();
 
     if let Some(ref sbat_level) = paths.sbat_level {
@@ -776,8 +947,8 @@ fn write_sbat_level(output: &mut Vec<u8>, paths: &PathStorage) -> Result<()> {
 
 /// Write a file as hex dump with ASCII representation
 fn write_hex_dump(output: &mut Vec<u8>, file_path: &str, name: &str) -> Result<()> {
-    let data = fs::read(file_path)
-        .with_context(|| format!("Failed to read file: {}", file_path))?;
+    let data =
+        fs::read(file_path).with_context(|| format!("Failed to read file: {}", file_path))?;
 
     write_raw_hex_dump(output, &data, name)?;
 

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -35,12 +35,12 @@ impl Machine<'_> {
             generate_acpi_tables(self.metadata_path, self.distribution, self.qemu_version)?;
         }
 
-        let tables  = read_file_data(self.acpi_tables)?;
+        let tables = read_file_data(self.acpi_tables)?;
 
         let rsdp: Vec<u8> = if !self.rsdp.is_empty() {
             read_file_data(self.rsdp)?
         } else {
-            let (rsdt_offset, _rsdt_csum, _rsdt_len) = find_acpi_table(&tables , "RSDT")?;
+            let (rsdt_offset, _rsdt_csum, _rsdt_len) = find_acpi_table(&tables, "RSDT")?;
 
             // Generate RSDP
             let mut rsdp = Vec::with_capacity(20);
@@ -115,8 +115,16 @@ fn derive_table_loader(tables: &[u8]) -> Result<Vec<u8>> {
     let (rsdt_offset, rsdt_csum, rsdt_len) = find("RSDT")?;
 
     let mut loader = TableLoader::new();
-    loader.append(LoaderCmd::Allocate { file: RSDP_FILE, alignment: 16, zone: 2 });
-    loader.append(LoaderCmd::Allocate { file: TABLES_FILE, alignment: 64, zone: 1 });
+    loader.append(LoaderCmd::Allocate {
+        file: RSDP_FILE,
+        alignment: 16,
+        zone: 2,
+    });
+    loader.append(LoaderCmd::Allocate {
+        file: TABLES_FILE,
+        alignment: 64,
+        zone: 1,
+    });
     loader.append(LoaderCmd::AddChecksum {
         file: TABLES_FILE,
         result_offset: dsdt_csum,
@@ -331,21 +339,22 @@ struct QemuPkg<'a> {
 
 fn qemu_pkg_for<'a>(distribution: &str, version_override: Option<&'a str>) -> Result<QemuPkg<'a>> {
     // Pinned defaults for reproducibility; override via `--qemu-version`.
-    let (source, default_version, image_digest): (&'static str, &'static str, &'static str) = match distribution {
-        "ubuntu:25.04" => (
-            "ppa",
-            "1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2",
-            "sha256:27771fb7b40a58237c98e8d3e6b9ecdd9289cec69a857fccfb85ff36294dac20",
-        ),
-        "ubuntu:26.04" => (
-            "main",
-            "1:10.2.1+ds-1ubuntu4",
-            "sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64",
-        ),
-        other => bail!(
-            "Unsupported distribution: {other}. Supported: ubuntu:25.04, ubuntu:26.04"
-        ),
-    };
+    let (source, default_version, image_digest): (&'static str, &'static str, &'static str) =
+        match distribution {
+            "ubuntu:25.04" => (
+                "ppa",
+                "1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2",
+                "sha256:27771fb7b40a58237c98e8d3e6b9ecdd9289cec69a857fccfb85ff36294dac20",
+            ),
+            "ubuntu:26.04" => (
+                "main",
+                "1:10.2.1+ds-1ubuntu4",
+                "sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64",
+            ),
+            other => {
+                bail!("Unsupported distribution: {other}. Supported: ubuntu:25.04, ubuntu:26.04")
+            }
+        };
     Ok(QemuPkg {
         source,
         version: version_override.unwrap_or(default_version),
@@ -368,34 +377,48 @@ fn build_qemu_args(qemu: Option<&QemuShape>, cpus: u8, memory: &str) -> Vec<OsSt
 
     match qemu {
         Some(q) => {
-            push(&mut args, "-accel",     &q.accel);
-            push(&mut args, "-m",         memory);
-            push(&mut args, "-smp",       &format!("{cpus},maxcpus={cpus}"));
-            push(&mut args, "-cpu",       &q.cpu);
+            push(&mut args, "-accel", &q.accel);
+            push(&mut args, "-m", memory);
+            push(&mut args, "-smp", &format!("{cpus},maxcpus={cpus}"));
+            push(&mut args, "-cpu", &q.cpu);
             args.push("-no-reboot".into());
             args.push("-nodefaults".into());
-            push(&mut args, "-vga",       "none");
+            push(&mut args, "-vga", "none");
             args.push("-nographic".into());
-            push(&mut args, "-bios",      OVMF_IN_CONTAINER);
-            push(&mut args, "-machine",   &q.machine);
-            for v in &q.globals { push(&mut args, "-global", v); }
-            for v in &q.objects { push(&mut args, "-object", v); }
-            for v in &q.netdevs { push(&mut args, "-netdev", v); }
-            for v in &q.devices { push(&mut args, "-device", v); }
-            for v in &q.fw_cfg  { push(&mut args, "-fw_cfg", v); }
+            push(&mut args, "-bios", OVMF_IN_CONTAINER);
+            push(&mut args, "-machine", &q.machine);
+            for v in &q.globals {
+                push(&mut args, "-global", v);
+            }
+            for v in &q.objects {
+                push(&mut args, "-object", v);
+            }
+            for v in &q.netdevs {
+                push(&mut args, "-netdev", v);
+            }
+            for v in &q.devices {
+                push(&mut args, "-device", v);
+            }
+            for v in &q.fw_cfg {
+                push(&mut args, "-fw_cfg", v);
+            }
         }
         None => {
             // Canonical direct-boot defaults: minimal args from
             // https://github.com/canonical/tdx/blob/3.3/guest-tools/direct-boot/boot_direct.sh#L54
-            push(&mut args, "-accel",   "kvm");
-            push(&mut args, "-m",       memory);
-            push(&mut args, "-smp",     &cpus.to_string());
-            push(&mut args, "-cpu",     "host");
-            push(&mut args, "-machine", "q35,kernel-irqchip=split,hpet=off,smm=off,pic=off");
-            push(&mut args, "-bios",    OVMF_IN_CONTAINER);
+            push(&mut args, "-accel", "kvm");
+            push(&mut args, "-m", memory);
+            push(&mut args, "-smp", &cpus.to_string());
+            push(&mut args, "-cpu", "host");
+            push(
+                &mut args,
+                "-machine",
+                "q35,kernel-irqchip=split,hpet=off,smm=off,pic=off",
+            );
+            push(&mut args, "-bios", OVMF_IN_CONTAINER);
             args.push("-nographic".into());
             args.push("-nodefaults".into());
-            push(&mut args, "-serial",  "stdio");
+            push(&mut args, "-serial", "stdio");
         }
     }
     args
@@ -409,7 +432,10 @@ fn resolve_metadata_path(metadata_path: &Path, path: &str) -> PathBuf {
 /// Returns the host's `kvm` group id, if the group exists. Used to grant the
 /// container access to `/dev/kvm` and `/dev/vhost-vsock`.
 fn kvm_group_id() -> Option<String> {
-    let out = Command::new("getent").args(["group", "kvm"]).output().ok()?;
+    let out = Command::new("getent")
+        .args(["group", "kvm"])
+        .output()
+        .ok()?;
     if !out.status.success() {
         return None;
     }
@@ -434,11 +460,19 @@ fn build_docker_image(
         ),
         "main" => info!(
             "QEMU source: {distribution} main archive ({})",
-            if pkg.version.is_empty() { "latest" } else { pkg.version }
+            if pkg.version.is_empty() {
+                "latest"
+            } else {
+                pkg.version
+            }
         ),
         other => info!(
             "QEMU source: {other} ({})",
-            if pkg.version.is_empty() { "?" } else { pkg.version }
+            if pkg.version.is_empty() {
+                "?"
+            } else {
+                pkg.version
+            }
         ),
     }
 
@@ -446,11 +480,16 @@ fn build_docker_image(
     let status = Command::new("docker")
         .arg("build")
         .args(["--progress", "plain", "--tag", IMAGE_NAME])
-        .arg("--build-arg").arg(format!("DISTRIBUTION={pinned_image}"))
-        .arg("--build-arg").arg(format!("QEMU_SOURCE={}", pkg.source))
-        .arg("--build-arg").arg(format!("QEMU_VERSION={}", pkg.version))
-        .arg("--build-arg").arg(format!("ACPI_TABLES_NAME={acpi_tables_name}"))
-        .arg("--file").arg(dockerfile_dir.join("Dockerfile.qemu-acpi-dump"))
+        .arg("--build-arg")
+        .arg(format!("DISTRIBUTION={pinned_image}"))
+        .arg("--build-arg")
+        .arg(format!("QEMU_SOURCE={}", pkg.source))
+        .arg("--build-arg")
+        .arg(format!("QEMU_VERSION={}", pkg.version))
+        .arg("--build-arg")
+        .arg(format!("ACPI_TABLES_NAME={acpi_tables_name}"))
+        .arg("--file")
+        .arg(dockerfile_dir.join("Dockerfile.qemu-acpi-dump"))
         .arg(dockerfile_dir)
         .status()
         .context("Failed to invoke `docker build`")?;
@@ -498,8 +537,10 @@ fn run_docker_container(
     if need_vhost_vsock && Path::new("/dev/vhost-vsock").exists() {
         cmd.args(["--device", "/dev/vhost-vsock:/dev/vhost-vsock"]);
     }
-    cmd.arg("-v").arg(format!("{}:{OVMF_IN_CONTAINER}:ro", bios.display()));
-    cmd.arg("-v").arg(format!("{}:/output", output_dir.display()));
+    cmd.arg("-v")
+        .arg(format!("{}:{OVMF_IN_CONTAINER}:ro", bios.display()));
+    cmd.arg("-v")
+        .arg(format!("{}:/output", output_dir.display()));
     cmd.arg(IMAGE_NAME);
     cmd.args(qemu_args);
 
@@ -533,9 +574,12 @@ pub fn generate_acpi_tables(
         .canonicalize()
         .with_context(|| format!("BIOS file not found: {}", boot_config.bios))?;
     let acpi_tables_target = resolve_metadata_path(metadata_path, &boot_config.acpi_tables);
-    let acpi_tables_dir = acpi_tables_target
-        .parent()
-        .with_context(|| format!("acpi_tables has no parent dir: {}", acpi_tables_target.display()))?;
+    let acpi_tables_dir = acpi_tables_target.parent().with_context(|| {
+        format!(
+            "acpi_tables has no parent dir: {}",
+            acpi_tables_target.display()
+        )
+    })?;
     fs_err::create_dir_all(acpi_tables_dir)?;
     let acpi_tables_name = acpi_tables_target
         .file_name()
@@ -543,7 +587,10 @@ pub fn generate_acpi_tables(
         .context("acpi_tables path must end with a filename")?;
     info!(
         "ACPI gen config: cpus={}, memory={}, bios={}, target={}",
-        boot_config.cpus, boot_config.memory, bios.display(), acpi_tables_target.display()
+        boot_config.cpus,
+        boot_config.memory,
+        bios.display(),
+        acpi_tables_target.display()
     );
     if let Some(q) = &boot_config.qemu {
         info!(
@@ -565,7 +612,11 @@ pub fn generate_acpi_tables(
     let output_dir = tempfile::tempdir().context("Failed to create ACPI output dir")?;
     fs_err::set_permissions(output_dir.path(), std::fs::Permissions::from_mode(0o777))?;
 
-    let qemu_args = build_qemu_args(boot_config.qemu.as_ref(), boot_config.cpus, &boot_config.memory);
+    let qemu_args = build_qemu_args(
+        boot_config.qemu.as_ref(),
+        boot_config.cpus,
+        &boot_config.memory,
+    );
     let need_kvm = boot_config
         .qemu
         .as_ref()
@@ -573,13 +624,22 @@ pub fn generate_acpi_tables(
         .unwrap_or(true);
     let need_vhost_vsock = boot_config.qemu.is_some();
 
-    run_docker_container(&bios, output_dir.path(), &qemu_args, need_kvm, need_vhost_vsock)?;
+    run_docker_container(
+        &bios,
+        output_dir.path(),
+        &qemu_args,
+        need_kvm,
+        need_vhost_vsock,
+    )?;
 
     // Move the produced ACPI tables into place; `fs::copy` would inherit the
     // container's restrictive 0600 from the source, so widen to 0644 after.
     let produced = output_dir.path().join(acpi_tables_name);
     if !produced.exists() {
-        bail!("ACPI tables not found in container output: {}", produced.display());
+        bail!(
+            "ACPI tables not found in container output: {}",
+            produced.display()
+        );
     }
     fs_err::copy(&produced, &acpi_tables_target)?;
     fs_err::set_permissions(&acpi_tables_target, std::fs::Permissions::from_mode(0o644))?;
@@ -643,12 +703,7 @@ mod tests {
 
     #[test]
     fn list_acpi_tables_walks_blob_and_stops_at_padding() {
-        let blob = build_blob(&[
-            (b"FACS", 64),
-            (b"DSDT", 100),
-            (b"FACP", 244),
-            (b"RSDT", 40),
-        ]);
+        let blob = build_blob(&[(b"FACS", 64), (b"DSDT", 100), (b"FACP", 244), (b"RSDT", 40)]);
         let list = list_acpi_tables(&blob).unwrap();
         let sigs: Vec<&[u8]> = list.iter().map(|(s, ..)| s.as_slice()).collect();
         assert_eq!(sigs, [b"FACS".as_slice(), b"DSDT", b"FACP", b"RSDT"]);
@@ -721,7 +776,10 @@ mod tests {
             (b"RSDT", 52), // header (36) + 4 × 4-byte entries
         ]);
         let loader = derive_table_loader(&blob).unwrap();
-        let cmds: Vec<_> = split_cmds(&loader).into_iter().map(decode_loader_cmd).collect();
+        let cmds: Vec<_> = split_cmds(&loader)
+            .into_iter()
+            .map(decode_loader_cmd)
+            .collect();
 
         // Expected command sequence per the docstring on derive_table_loader.
         // Allocate rsdp + Allocate tables + AddChecksum DSDT + 3×AddPtr FACP + AddChecksum FACP
@@ -780,21 +838,30 @@ mod tests {
             (b"RSDT", 56),
         ]);
         let loader = derive_table_loader(&blob).unwrap();
-        let cmds: Vec<_> = split_cmds(&loader).into_iter().map(decode_loader_cmd).collect();
+        let cmds: Vec<_> = split_cmds(&loader)
+            .into_iter()
+            .map(decode_loader_cmd)
+            .collect();
 
         // 17 + 2 commands now: one extra AddChecksum HPET + one extra AddPtr RSDT entry.
         assert_eq!(cmds.len(), 19);
         // Count AddChecksums in `etc/acpi/tables` (i.e. tables blob, not rsdp).
-        let checksum_tables: Vec<_> = cmds.iter()
+        let checksum_tables: Vec<_> = cmds
+            .iter()
             .filter(|c| c.0 == 3 && c.1 == "etc/acpi/tables")
             .collect();
         // DSDT + FACP + APIC + HPET + MCFG + WAET + RSDT = 7
         assert_eq!(checksum_tables.len(), 7);
         // Count RSDT-entry AddPtrs (5 vs the 4 the old code emitted).
         let rsdt_off = 64 + 100 + 244 + 144 + 56 + 60 + 40;
-        let rsdt_ptrs: Vec<_> = cmds.iter()
-            .filter(|c| c.0 == 2 && c.1 == "etc/acpi/tables"
-                     && c.3[0] >= rsdt_off + 36 && c.3[0] < rsdt_off + 36 + 5 * 4)
+        let rsdt_ptrs: Vec<_> = cmds
+            .iter()
+            .filter(|c| {
+                c.0 == 2
+                    && c.1 == "etc/acpi/tables"
+                    && c.3[0] >= rsdt_off + 36
+                    && c.3[0] < rsdt_off + 36 + 5 * 4
+            })
             .collect();
         assert_eq!(rsdt_ptrs.len(), 5);
     }
@@ -837,15 +904,22 @@ mod tests {
         // Pinned because the Canonical-defaults scenario depends on this exact order.
         let args = build_qemu_args(None, 4, "2048M");
         let expected: Vec<&str> = vec![
-            "-accel", "kvm",
-            "-m", "2048M",
-            "-smp", "4",
-            "-cpu", "host",
-            "-machine", "q35,kernel-irqchip=split,hpet=off,smm=off,pic=off",
-            "-bios", OVMF_IN_CONTAINER,
+            "-accel",
+            "kvm",
+            "-m",
+            "2048M",
+            "-smp",
+            "4",
+            "-cpu",
+            "host",
+            "-machine",
+            "q35,kernel-irqchip=split,hpet=off,smm=off,pic=off",
+            "-bios",
+            OVMF_IN_CONTAINER,
             "-nographic",
             "-nodefaults",
-            "-serial", "stdio",
+            "-serial",
+            "stdio",
         ];
         let got: Vec<&str> = args.iter().map(|s| s.to_str().unwrap()).collect();
         assert_eq!(got, expected);
@@ -873,24 +947,39 @@ mod tests {
 
         // Core seven flags first (in a documented order), then -machine, then
         // user-supplied lists in -global / -object / -netdev / -device / -fw_cfg order.
-        assert_eq!(args, vec![
-            "-accel", "tcg",
-            "-m", "16384M",
-            "-smp", "8,maxcpus=8",
-            "-cpu", "Skylake-Server,phys-bits=46",
-            "-no-reboot",
-            "-nodefaults",
-            "-vga", "none",
-            "-nographic",
-            "-bios", OVMF_IN_CONTAINER,
-            "-machine", "q35,kernel_irqchip=split,smm=off,pic=off",
-            "-global", "q35-pcihost.pci-hole64-size=4096G",
-            "-object", "memory-backend-ram,id=mem0,size=16384M",
-            "-netdev", "hubport,id=net0,hubid=0",
-            "-device", "e1000,netdev=net0,bus=pcie.0,addr=0x2,romfile=",
-            "-device", "virtio-rng-pci",
-            "-fw_cfg", "name=opt/ovmf/X-PciMmio64Mb,string=262144",
-        ]);
+        assert_eq!(
+            args,
+            vec![
+                "-accel",
+                "tcg",
+                "-m",
+                "16384M",
+                "-smp",
+                "8,maxcpus=8",
+                "-cpu",
+                "Skylake-Server,phys-bits=46",
+                "-no-reboot",
+                "-nodefaults",
+                "-vga",
+                "none",
+                "-nographic",
+                "-bios",
+                OVMF_IN_CONTAINER,
+                "-machine",
+                "q35,kernel_irqchip=split,smm=off,pic=off",
+                "-global",
+                "q35-pcihost.pci-hole64-size=4096G",
+                "-object",
+                "memory-backend-ram,id=mem0,size=16384M",
+                "-netdev",
+                "hubport,id=net0,hubid=0",
+                "-device",
+                "e1000,netdev=net0,bus=pcie.0,addr=0x2,romfile=",
+                "-device",
+                "virtio-rng-pci",
+                "-fw_cfg",
+                "name=opt/ovmf/X-PciMmio64Mb,string=262144",
+            ]
+        );
     }
-
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -3,17 +3,19 @@
  * Copyright (c) 2025 Tinfoil Inc
  * SPDX-License-Identifier: Apache-2.0
  */
-use crate::{measure_log, measure_sha384, util::{debug_print_log, authenticode_sha384_hash}};
+use crate::util::utf16_encode;
+use crate::{
+    measure_log, measure_sha384,
+    util::{authenticode_sha384_hash, debug_print_log},
+};
 use anyhow::{bail, Context, Result};
+use log::debug;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use log::debug;
-use crate::util::utf16_encode;
 
 /// Helper function to download a file using guestfish
 fn guestfish_download(qcow2_path: &str, source_path: &str) -> Result<Vec<u8>> {
-
     // Create a temporary directory for the extracted files
     let temp_dir = std::env::temp_dir().join("tdx_bootloader_extract");
     std::fs::create_dir_all(&temp_dir)?;
@@ -24,19 +26,30 @@ fn guestfish_download(qcow2_path: &str, source_path: &str) -> Result<Vec<u8>> {
     // Download the file using guestfish
     let output = Command::new("guestfish")
         .args(&[
-            "--ro", "-a", qcow2_path, "-i",
-            "download", source_path, dest_path.to_str().unwrap()
+            "--ro",
+            "-a",
+            qcow2_path,
+            "-i",
+            "download",
+            source_path,
+            dest_path.to_str().unwrap(),
         ])
         .output()
         .context(format!("Failed to extract {}", source_path))?;
 
     if !output.status.success() {
-        bail!("Failed to extract {}: {}", source_path, String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to extract {}: {}",
+            source_path,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     // Read the extracted file
-    let data = std::fs::read(&dest_path)
-        .context(format!("Failed to read extracted {}", dest_path.to_str().unwrap()))?;
+    let data = std::fs::read(&dest_path).context(format!(
+        "Failed to read extracted {}",
+        dest_path.to_str().unwrap()
+    ))?;
 
     // Cleanup
     let _ = std::fs::remove_dir_all(&temp_dir);
@@ -49,15 +62,24 @@ fn extract_gpt_event_data(qcow2_path: &str) -> Result<Vec<u8>> {
     // Extract GPT header from LBA 1 (skip MBR at LBA 0)
     let output = Command::new("guestfish")
         .args(&[
-            "--ro", "-a", qcow2_path,
-            "run", ":",
-            "pread-device", "/dev/sda", "512", "512"  // Read LBA 1 (GPT header)
+            "--ro",
+            "-a",
+            qcow2_path,
+            "run",
+            ":",
+            "pread-device",
+            "/dev/sda",
+            "512",
+            "512", // Read LBA 1 (GPT header)
         ])
         .output()
         .context("Failed to extract GPT header")?;
 
     if !output.status.success() {
-        bail!("Failed to extract GPT header: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to extract GPT header: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     let gpt_header = output.stdout;
@@ -87,15 +109,24 @@ fn extract_gpt_event_data(qcow2_path: &str) -> Result<Vec<u8>> {
 
     let output = Command::new("guestfish")
         .args(&[
-            "--ro", "-a", qcow2_path,
-            "run", ":",
-            "pread-device", "/dev/sda", &entries_length.to_string(), &entries_offset.to_string()
+            "--ro",
+            "-a",
+            qcow2_path,
+            "run",
+            ":",
+            "pread-device",
+            "/dev/sda",
+            &entries_length.to_string(),
+            &entries_offset.to_string(),
         ])
         .output()
         .context("Failed to extract GPT entries")?;
 
     if !output.status.success() {
-        bail!("Failed to extract GPT entries: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to extract GPT entries: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     let all_entries = output.stdout;
@@ -144,9 +175,7 @@ fn read_file_data(filename: &str) -> Result<Vec<u8>> {
     let path = Path::new(filename);
     if path.exists() {
         match fs::read(path) {
-            Ok(data) => {
-                Ok(data)
-            }
+            Ok(data) => Ok(data),
             Err(e) => {
                 debug!("Failed to read {}: {}", filename, e);
                 // Return empty data if file doesn't exist or can't be read
@@ -175,12 +204,14 @@ fn extract_kernel_version_from_cmdline(cmdline: &str) -> Result<String> {
             }
         }
     }
-    bail!("Could not extract kernel version from command line: {}", cmdline);
+    bail!(
+        "Could not extract kernel version from command line: {}",
+        cmdline
+    );
 }
 
 /// Main function to measure RTMR1 from a qcow2 disk image
 pub fn measure_rtmr1_from_qcow2(qcow2_path: &str) -> Result<Vec<u8>> {
-
     // Extract bootloader files
     let gpt_data = extract_gpt_event_data(qcow2_path)?;
     let shim_data = guestfish_download(qcow2_path, "/boot/efi/EFI/ubuntu/shimx64.efi")?;
@@ -207,8 +238,13 @@ pub fn measure_rtmr1_from_qcow2(qcow2_path: &str) -> Result<Vec<u8>> {
 }
 
 /// Measures RTMR2 using actual MOK variable data extracted from shim
-pub fn measure_rtmr2_from_qcow2(qcow2_path: &str, cmdline: &str, ref_mok_list: &str, ref_mok_list_trusted: &str, ref_mok_list_x: &str) -> Result<Vec<u8>> {
-
+pub fn measure_rtmr2_from_qcow2(
+    qcow2_path: &str,
+    cmdline: &str,
+    ref_mok_list: &str,
+    ref_mok_list_trusted: &str,
+    ref_mok_list_x: &str,
+) -> Result<Vec<u8>> {
     // Extract reference MOK variables
     let ref_mok_list_data = read_file_data(ref_mok_list)?;
     let ref_mok_list_trusted_data = read_file_data(ref_mok_list_trusted)?;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2025 Tinfoil Inc
  * SPDX-License-Identifier: Apache-2.0
  */
-use crate::{measure_log, measure_sha384, util::debug_print_log, util::authenticode_sha384_hash};
+use crate::{measure_log, measure_sha384, util::authenticode_sha384_hash, util::debug_print_log};
 use anyhow::{bail, Context, Result};
 use fs_err as fs;
 
@@ -99,7 +99,6 @@ pub(crate) fn measure_rtmr1_direct(
     mem_size: u64,
     acpi_data_size: u32,
 ) -> Result<Vec<u8>> {
-
     // Read kernel and initrd files
     let kernel_data = fs::read(kernel_path).context("Failed to read kernel file")?;
     let initrd_data = fs::read(initrd_path).context("Failed to read initrd file")?;
@@ -124,11 +123,7 @@ pub(crate) fn measure_rtmr1_direct(
 }
 
 /// Measures RTMR2 for direct boot from file paths.
-pub(crate) fn measure_rtmr2_direct(
-    initrd_path: &str,
-    kernel_cmdline: &str,
-) -> Result<Vec<u8>> {
-
+pub(crate) fn measure_rtmr2_direct(initrd_path: &str, kernel_cmdline: &str) -> Result<Vec<u8>> {
     // Reads our initrd file
     let initrd_data = fs::read(initrd_path).context("Failed to read initrd file")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,17 @@
  * Copyright (c) 2025 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use serde_human_bytes as hex_bytes;
-use anyhow::{anyhow, Result};
 
 pub use machine::Machine;
 
 use util::{measure_log, measure_sha384};
 
 mod acpi;
-mod kernel;
 mod image;
+mod kernel;
 mod machine;
 mod num;
 mod tdvf;
@@ -72,8 +72,12 @@ pub struct QemuShape {
     pub fw_cfg: Vec<String>,
 }
 
-fn default_cpu() -> String { "host".to_string() }
-fn default_accel() -> String { "kvm".to_string() }
+fn default_cpu() -> String {
+    "host".to_string()
+}
+fn default_accel() -> String {
+    "kvm".to_string()
+}
 
 /// Direct boot specific information
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -142,7 +146,9 @@ impl ImageConfig {
 
     /// Get CPU count from boot config
     pub fn cpu_count(&self) -> Result<u8> {
-        let boot_config = self.boot_config.as_ref()
+        let boot_config = self
+            .boot_config
+            .as_ref()
             .ok_or_else(|| anyhow!("Boot config is required"))?;
 
         Ok(boot_config.cpus)
@@ -150,7 +156,9 @@ impl ImageConfig {
 
     /// Get memory size from boot config
     pub fn memory_size(&self) -> Result<u64> {
-        let boot_config = self.boot_config.as_ref()
+        let boot_config = self
+            .boot_config
+            .as_ref()
             .ok_or_else(|| anyhow!("Boot config is required"))?;
 
         parse_memory_size(&boot_config.memory)

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use crate::tdvf::Tdvf;
-use crate::{kernel, image, TdxMeasurements};
+use crate::{image, kernel, TdxMeasurements};
 use anyhow::{Context, Result};
 use fs_err as fs;
 use log::debug;
@@ -51,20 +51,39 @@ impl Machine<'_> {
 
         // Direct boot
         if self.direct_boot {
-            let kernel_path = self.kernel.ok_or_else(|| anyhow::anyhow!("Kernel path required for direct boot"))?;
-            let initrd_path = self.initrd.ok_or_else(|| anyhow::anyhow!("Initrd path required for direct boot"))?;
+            let kernel_path = self
+                .kernel
+                .ok_or_else(|| anyhow::anyhow!("Kernel path required for direct boot"))?;
+            let initrd_path = self
+                .initrd
+                .ok_or_else(|| anyhow::anyhow!("Initrd path required for direct boot"))?;
 
-            rtmr1 = kernel::measure_rtmr1_direct(kernel_path, initrd_path, self.memory_size, 0x28000)?;
+            rtmr1 =
+                kernel::measure_rtmr1_direct(kernel_path, initrd_path, self.memory_size, 0x28000)?;
             rtmr2 = kernel::measure_rtmr2_direct(initrd_path, self.kernel_cmdline)?;
-
-        } else { // Indirect boot
-            let qcow2_path = self.qcow2.ok_or_else(|| anyhow::anyhow!("Qcow2 path required for indirect boot"))?;
-            let mok_list_path = self.mok_list.ok_or_else(|| anyhow::anyhow!("MOK list path required for indirect boot"))?;
-            let mok_list_trusted_path = self.mok_list_trusted.ok_or_else(|| anyhow::anyhow!("MOK list trusted path required for indirect boot"))?;
-            let mok_list_x_path = self.mok_list_x.ok_or_else(|| anyhow::anyhow!("MOK list X path required for indirect boot"))?;
+        } else {
+            // Indirect boot
+            let qcow2_path = self
+                .qcow2
+                .ok_or_else(|| anyhow::anyhow!("Qcow2 path required for indirect boot"))?;
+            let mok_list_path = self
+                .mok_list
+                .ok_or_else(|| anyhow::anyhow!("MOK list path required for indirect boot"))?;
+            let mok_list_trusted_path = self.mok_list_trusted.ok_or_else(|| {
+                anyhow::anyhow!("MOK list trusted path required for indirect boot")
+            })?;
+            let mok_list_x_path = self
+                .mok_list_x
+                .ok_or_else(|| anyhow::anyhow!("MOK list X path required for indirect boot"))?;
 
             rtmr1 = image::measure_rtmr1_from_qcow2(qcow2_path)?;
-            rtmr2 = image::measure_rtmr2_from_qcow2(qcow2_path, self.kernel_cmdline, mok_list_path, mok_list_trusted_path, mok_list_x_path)?;
+            rtmr2 = image::measure_rtmr2_from_qcow2(
+                qcow2_path,
+                self.kernel_cmdline,
+                mok_list_path,
+                mok_list_trusted_path,
+                mok_list_x_path,
+            )?;
         }
 
         Ok(TdxMeasurements {
@@ -95,21 +114,39 @@ impl Machine<'_> {
 
         // Direct boot
         if self.direct_boot {
-            let kernel_path = self.kernel.ok_or_else(|| anyhow::anyhow!("Kernel path required for direct boot"))?;
-            let initrd_path = self.initrd.ok_or_else(|| anyhow::anyhow!("Initrd path required for direct boot"))?;
+            let kernel_path = self
+                .kernel
+                .ok_or_else(|| anyhow::anyhow!("Kernel path required for direct boot"))?;
+            let initrd_path = self
+                .initrd
+                .ok_or_else(|| anyhow::anyhow!("Initrd path required for direct boot"))?;
 
             // WARN : Carefull, when measuring the runtime only, we only compute the measurement for memory size > 0xb0000000
             rtmr1 = kernel::measure_rtmr1_direct(kernel_path, initrd_path, 0xb0000000, 0x28000)?;
             rtmr2 = kernel::measure_rtmr2_direct(initrd_path, self.kernel_cmdline)?;
-
-        } else { // Indirect boot
-            let qcow2_path = self.qcow2.ok_or_else(|| anyhow::anyhow!("Qcow2 path required for indirect boot"))?;
-            let mok_list_path = self.mok_list.ok_or_else(|| anyhow::anyhow!("MOK list path required for indirect boot"))?;
-            let mok_list_trusted_path = self.mok_list_trusted.ok_or_else(|| anyhow::anyhow!("MOK list trusted path required for indirect boot"))?;
-            let mok_list_x_path = self.mok_list_x.ok_or_else(|| anyhow::anyhow!("MOK list X path required for indirect boot"))?;
+        } else {
+            // Indirect boot
+            let qcow2_path = self
+                .qcow2
+                .ok_or_else(|| anyhow::anyhow!("Qcow2 path required for indirect boot"))?;
+            let mok_list_path = self
+                .mok_list
+                .ok_or_else(|| anyhow::anyhow!("MOK list path required for indirect boot"))?;
+            let mok_list_trusted_path = self.mok_list_trusted.ok_or_else(|| {
+                anyhow::anyhow!("MOK list trusted path required for indirect boot")
+            })?;
+            let mok_list_x_path = self
+                .mok_list_x
+                .ok_or_else(|| anyhow::anyhow!("MOK list X path required for indirect boot"))?;
 
             rtmr1 = image::measure_rtmr1_from_qcow2(qcow2_path)?;
-            rtmr2 = image::measure_rtmr2_from_qcow2(qcow2_path, self.kernel_cmdline, mok_list_path, mok_list_trusted_path, mok_list_x_path)?;
+            rtmr2 = image::measure_rtmr2_from_qcow2(
+                qcow2_path,
+                self.kernel_cmdline,
+                mok_list_path,
+                mok_list_trusted_path,
+                mok_list_x_path,
+            )?;
         }
 
         Ok(TdxMeasurements {

--- a/src/tdvf.rs
+++ b/src/tdvf.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha384};
 
 use crate::num::read_le;
-use crate::util::{debug_print_log, measure_sha384, measure_log, utf16_encode, read_file_data};
+use crate::util::{debug_print_log, measure_log, measure_sha384, read_file_data, utf16_encode};
 use crate::Machine;
 
 const PAGE_SIZE: u64 = 0x1000;
@@ -64,7 +64,11 @@ fn encode_guid(guid_str: &str) -> Result<Vec<u8>> {
 }
 
 /// Measures an EFI variable event.
-fn measure_tdx_efi_variable(vendor_guid: &str, var_name: &str, var_data: Option<&[u8]>) -> Result<Vec<u8>> {
+fn measure_tdx_efi_variable(
+    vendor_guid: &str,
+    var_name: &str,
+    var_data: Option<&[u8]>,
+) -> Result<Vec<u8>> {
     let mut data = Vec::new();
     data.extend_from_slice(&encode_guid(vendor_guid)?);
     data.extend_from_slice(&(var_name.len() as u64).to_le_bytes());
@@ -295,7 +299,8 @@ impl<'a> Tdvf<'a> {
         if machine.direct_boot {
             // Boot0000 data for direct boot mode
             let boot0000_hex = "090100002c0055006900410070007000000004071400c9bdb87cebf8344faaea3ee4af6516a10406140021aa2c4614760345836e8ab6f46623317fff0400";
-            let boot0000 = hex::decode(boot0000_hex).context("Failed to decode boot0000 hex string")?;
+            let boot0000 =
+                hex::decode(boot0000_hex).context("Failed to decode boot0000 hex string")?;
             rtmr0_log.push(measure_sha384(&boot0000));
         } else {
             for boot_entry_num in boot_entries {
@@ -307,7 +312,11 @@ impl<'a> Tdvf<'a> {
 
         // Add SbatLevel if not direct boot
         if !machine.direct_boot {
-            rtmr0_log.push(measure_tdx_efi_variable("605DAB50-E046-4300-ABB6-3DD810DD8B23", "SbatLevel", Some(b"sbat,1,2021030218\n"))?);
+            rtmr0_log.push(measure_tdx_efi_variable(
+                "605DAB50-E046-4300-ABB6-3DD810DD8B23",
+                "SbatLevel",
+                Some(b"sbat,1,2021030218\n"),
+            )?);
         }
 
         debug_print_log("RTMR0", &rtmr0_log);

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,11 +3,11 @@
  * Copyright (c) 2025 Tinfoil Inc
  * SPDX-License-Identifier: Apache-2.0
  */
-use log::debug;
-use sha2::{Digest, Sha384};
-use crate::{num::read_le};
+use crate::num::read_le;
 use anyhow::{bail, Result};
+use log::debug;
 use object::pe;
+use sha2::{Digest, Sha384};
 use std::fs;
 
 /// Computes a SHA384 hash of the given data.

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -15,7 +15,9 @@ use std::path::{Path, PathBuf};
 use tdx_measure::{ImageConfig, Machine};
 
 fn fixtures_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures")
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
 }
 
 fn ovmf_path() -> PathBuf {
@@ -48,8 +50,7 @@ struct Expected {
 /// absolute repo path into the checked-in fixture), and builds a Machine the
 /// caller can `measure_platform()` on.
 fn machine_for(fixture: &Path) -> (ImageConfig, PathBuf) {
-    let raw = std::fs::read_to_string(fixture.join("metadata.json"))
-        .expect("read metadata.json");
+    let raw = std::fs::read_to_string(fixture.join("metadata.json")).expect("read metadata.json");
     let cfg: ImageConfig = serde_json::from_str(&raw).expect("parse metadata.json");
     (cfg, fixture.join("metadata.json"))
 }
@@ -67,8 +68,7 @@ fn measure_platform_matches_expected_json_for_every_fixture() {
     for fixture in discover_fixtures() {
         let name = fixture.file_name().unwrap().to_string_lossy().into_owned();
         let expected: Expected = serde_json::from_reader(
-            std::fs::File::open(fixture.join("expected.json"))
-                .expect("read expected.json"),
+            std::fs::File::open(fixture.join("expected.json")).expect("read expected.json"),
         )
         .expect("parse expected.json");
 

--- a/tests/regen.rs
+++ b/tests/regen.rs
@@ -19,7 +19,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn fixtures_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures")
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
 }
 
 fn cli_binary() -> PathBuf {
@@ -90,7 +92,11 @@ fn create_acpi_tables_reproduces_each_fixture_byte_for_byte() {
 
         // Each fixture has been tested against ubuntu:25.04 (Canonical fallback)
         // or ubuntu:26.04 (qemu block). Pick by inspecting the metadata.
-        let distro = if accel == "kvm" { "ubuntu:25.04" } else { "ubuntu:26.04" };
+        let distro = if accel == "kvm" {
+            "ubuntu:25.04"
+        } else {
+            "ubuntu:26.04"
+        };
 
         let status = Command::new(&cli)
             .arg(fixture.join("metadata.json"))
@@ -102,7 +108,9 @@ fn create_acpi_tables_reproduces_each_fixture_byte_for_byte() {
         if !captured.exists() {
             // Re-stash so the post-comparison can fail meaningfully.
             std::fs::rename(&stash, &captured).expect("restore captured bytes");
-            panic!("{name}: --create-acpi-tables didn't produce acpi_tables.bin (status={status:?})");
+            panic!(
+                "{name}: --create-acpi-tables didn't produce acpi_tables.bin (status={status:?})"
+            );
         }
         let regenerated = std::fs::read(&captured).expect("read regenerated acpi_tables.bin");
         // Replace the just-generated file with the captured one so subsequent


### PR DESCRIPTION
Reformats the Rust sources with `cargo fmt` and adds a CI check so they stay formatted.

Now rebased onto `main` (post-#71 and #72), so the PR contains only its own two commits:

| commit |
|---|
| style: format Rust sources with cargo fmt |
| ci: enforce rustfmt formatting |

The `chore: ignore the reformat commit in git blame` commit has been dropped, as agreed on #72 — `.git-blame-ignore-revs` will be added in a separate PR once the final merge hashes for the cargo-sort and rustfmt commits are known.

### Why

`cli/src` had drifted out of rustfmt compliance because the crate was not part of a workspace, so a root `cargo fmt --all` never reached it. #71 closed that coverage gap, this PR applies the resulting reformat and locks it in.

The reformat is mechanical and touches many lines, so it is isolated in its own commit. The CI job requests the `rustfmt` component explicitly, so the check does not depend on the hosted image happening to ship it. The `cargo fmt --all -- --check` step is ordered before the `cargo-sort` check from #72 because it needs no `cargo install` and therefore fails faster.

### Verification

`cargo fmt --all -- --check`, `cargo sort --check --workspace` and `cargo test --workspace` (11 passed, 1 Docker-gated ignore) all pass. The reformat is whitespace-only: no test expectations change.
